### PR TITLE
Bump esphome to 2026.6.0

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/esphome/esphome:2026.5.3
+FROM ghcr.io/esphome/esphome:2026.6.0
 
 COPY ./src/config /config
 


### PR DESCRIPTION
Automated bump of esphome to 2026.6.0

Closes: #138